### PR TITLE
第1章 自分の面談日程の表示・登録・編集・削除機能

### DIFF
--- a/app/assets/javascripts/interviews.coffee
+++ b/app/assets/javascripts/interviews.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/interviews.scss
+++ b/app/assets/stylesheets/interviews.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Interviews controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,84 @@
+body {
+  background-color: #fff;
+  color: #333;
+  margin: 33px;
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px;
+}
+
+a {
+  color: #000;
+
+  &:visited {
+    color: #666;
+  }
+
+  &:hover {
+    color: #fff;
+    background-color: #000;
+  }
+}
+
+th {
+  padding-bottom: 5px;
+}
+
+td {
+  padding: 0 5px 7px;
+}
+
+div {
+  &.field, &.actions {
+    margin-bottom: 10px;
+  }
+}
+
+#notice {
+  color: green;
+}
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table;
+}
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px 7px 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0;
+
+  h2 {
+    text-align: left;
+    font-weight: bold;
+    padding: 5px 5px 5px 15px;
+    font-size: 12px;
+    margin: -7px -7px 0;
+    background-color: #c00;
+    color: #fff;
+  }
+
+  ul li {
+    font-size: 12px;
+    list-style: square;
+  }
+}
+
+label {
+  display: block;
+}

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,34 +1,36 @@
 class InterviewsController < ApplicationController
+  before_action :set_user
   before_action :set_interview, only: [:show, :edit, :update, :destroy]
 
-  # GET /interviews
-  # GET /interviews.json
+  # GET /users/:user_id/interviews
+  # GET /users/:user_id/interviews.json
   def index
-    @interviews = Interview.all
+    @interviews = @user.interviews.order("start_time")
   end
 
-  # GET /interviews/1
-  # GET /interviews/1.json
+  # GET /users/:user_id/interviews/:id
+  # GET /users/:user_id/interviews/:id.json
   def show
   end
 
-  # GET /interviews/new
+  # GET /users/:user_id/interviews/new
   def new
-    @interview = Interview.new
+    @interview = @user.interviews.build
   end
 
-  # GET /interviews/1/edit
+  # GET /users/:user_id/interviews/:id/edit
   def edit
   end
 
-  # POST /interviews
-  # POST /interviews.json
+  # POST /users/:user_id/interviews
+  # POST /users/:user_id/interviews.json
   def create
-    @interview = Interview.new(interview_params)
+    @interview = @user.interviews.build(interview_params)
 
     respond_to do |format|
       if @interview.save
-        format.html { redirect_to @interview, notice: 'Interview was successfully created.' }
+        format.html { redirect_to user_interview_path(@user, @interview),
+          notice: 'Interview was successfully created.' }
         format.json { render :show, status: :created, location: @interview }
       else
         format.html { render :new }
@@ -37,12 +39,13 @@ class InterviewsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /interviews/1
-  # PATCH/PUT /interviews/1.json
+  # PATCH/PUT /users/:user_id/interviews/:id
+  # PATCH/PUT /users/:user_id/interviews/:id.json
   def update
     respond_to do |format|
       if @interview.update(interview_params)
-        format.html { redirect_to @interview, notice: 'Interview was successfully updated.' }
+        format.html { redirect_to user_interview_path(@user, @interview),
+          notice: 'Interview was successfully updated.' }
         format.json { render :show, status: :ok, location: @interview }
       else
         format.html { render :edit }
@@ -51,20 +54,25 @@ class InterviewsController < ApplicationController
     end
   end
 
-  # DELETE /interviews/1
-  # DELETE /interviews/1.json
+  # DELETE /users/:user_id/interviews/:id
+  # DELETE /users/:user_id/interviews/:id.json
   def destroy
     @interview.destroy
     respond_to do |format|
-      format.html { redirect_to interviews_url, notice: 'Interview was successfully destroyed.' }
+      format.html { redirect_to user_interviews_url(@user),
+        notice: 'Interview was successfully destroyed.' }
       format.json { head :no_content }
     end
   end
 
   private
     # Use callbacks to share common setup or constraints between actions.
+    def set_user
+      @user = User.find(params[:user_id])
+    end
+
     def set_interview
-      @interview = Interview.find(params[:id])
+      @interview = @user.interviews.find(params[:id])
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,0 +1,74 @@
+class InterviewsController < ApplicationController
+  before_action :set_interview, only: [:show, :edit, :update, :destroy]
+
+  # GET /interviews
+  # GET /interviews.json
+  def index
+    @interviews = Interview.all
+  end
+
+  # GET /interviews/1
+  # GET /interviews/1.json
+  def show
+  end
+
+  # GET /interviews/new
+  def new
+    @interview = Interview.new
+  end
+
+  # GET /interviews/1/edit
+  def edit
+  end
+
+  # POST /interviews
+  # POST /interviews.json
+  def create
+    @interview = Interview.new(interview_params)
+
+    respond_to do |format|
+      if @interview.save
+        format.html { redirect_to @interview, notice: 'Interview was successfully created.' }
+        format.json { render :show, status: :created, location: @interview }
+      else
+        format.html { render :new }
+        format.json { render json: @interview.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /interviews/1
+  # PATCH/PUT /interviews/1.json
+  def update
+    respond_to do |format|
+      if @interview.update(interview_params)
+        format.html { redirect_to @interview, notice: 'Interview was successfully updated.' }
+        format.json { render :show, status: :ok, location: @interview }
+      else
+        format.html { render :edit }
+        format.json { render json: @interview.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /interviews/1
+  # DELETE /interviews/1.json
+  def destroy
+    @interview.destroy
+    respond_to do |format|
+      format.html { redirect_to interviews_url, notice: 'Interview was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_interview
+      @interview = Interview.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def interview_params
+      params.require(:interview).permit(:start_time, :status, :user_id)
+    end
+end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -5,6 +5,7 @@ class InterviewsController < ApplicationController
   # GET /users/:user_id/interviews
   # GET /users/:user_id/interviews.json
   def index
+    # 開始時間順にソート
     @interviews = @user.interviews.order("start_time")
   end
 
@@ -30,7 +31,7 @@ class InterviewsController < ApplicationController
     respond_to do |format|
       if @interview.save
         format.html { redirect_to user_interview_path(@user, @interview),
-          notice: 'Interview was successfully created.' }
+          notice: t("interviews.created") }
         format.json { render :show, status: :created, location: @interview }
       else
         format.html { render :new }
@@ -45,7 +46,7 @@ class InterviewsController < ApplicationController
     respond_to do |format|
       if @interview.update(interview_params)
         format.html { redirect_to user_interview_path(@user, @interview),
-          notice: 'Interview was successfully updated.' }
+          notice: t("interviews.updated") }
         format.json { render :show, status: :ok, location: @interview }
       else
         format.html { render :edit }
@@ -60,7 +61,7 @@ class InterviewsController < ApplicationController
     @interview.destroy
     respond_to do |format|
       format.html { redirect_to user_interviews_url(@user),
-        notice: 'Interview was successfully destroyed.' }
+        notice: t("interviews.destroyed") }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,6 +1,7 @@
 class InterviewsController < ApplicationController
   before_action :set_user
   before_action :set_interview, only: [:show, :edit, :update, :destroy]
+  before_action :my_interviews?
 
   # GET /users/:user_id/interviews
   # GET /users/:user_id/interviews.json
@@ -79,5 +80,12 @@ class InterviewsController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def interview_params
       params.require(:interview).permit(:start_time, :status, :user_id)
+    end
+
+    def my_interviews?
+      # ログイン中ユーザーの面接一覧でないなら、ログインユーザーの面接一覧にとりあえずリダイレクト
+      if current_user.id != @user.id
+        redirect_to user_interviews_url(:user_id => current_user.id)
+      end
     end
 end

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -1,0 +1,2 @@
+module InterviewsHelper
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,0 +1,3 @@
+class Interview < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,3 +1,5 @@
 class Interview < ApplicationRecord
   belongs_to :user
+
+  enum status: { approved: 0, on_hold: 1, rejected: 2 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ApplicationRecord
          :rememberable, :trackable, :validatable
 
   enum gender: { male: 0, female: 1, other: 2 }
+
+  has_many :interviews, dependent: :destroy
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -85,7 +85,7 @@
 
 <p>
   <%= button_to t("registrations.destroy"), registration_path(resource_name),
-    data: { confirm: t("registrations.destroy_confirmation") },
+    data: { confirm: t("helpers.destroy_confirmation") },
     method: :delete
   %>
 </p>

--- a/app/views/interviews/_form.html.erb
+++ b/app/views/interviews/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: interview, local: true) do |form| %>
+<%= form_with(model: [@user, interview], local: true) do |form| %>
   <% if interview.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(interview.errors.count, "error") %> prohibited this interview from being saved:</h2>
@@ -11,19 +11,10 @@
     </div>
   <% end %>
 
-  <div class="field">
-    <%= form.label :start_time %>
-    <%= form.datetime_select :start_time, id: :interview_start_time %>
-  </div>
-
-  <div class="field">
-    <%= form.label :status %>
-    <%= form.number_field :status, id: :interview_status %>
-  </div>
-
-  <div class="field">
-    <%= form.label :user_id %>
-    <%= form.text_field :user_id, id: :interview_user_id %>
+  <div class="form-group">
+    <%= form.label :start_time %>:<br>
+    <%= form.datetime_select :start_time, id: :interview_start_time,
+      start_year: Date.today.year %>
   </div>
 
   <div class="actions">

--- a/app/views/interviews/_form.html.erb
+++ b/app/views/interviews/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: interview, local: true) do |form| %>
+  <% if interview.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(interview.errors.count, "error") %> prohibited this interview from being saved:</h2>
+
+      <ul>
+      <% interview.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :start_time %>
+    <%= form.datetime_select :start_time, id: :interview_start_time %>
+  </div>
+
+  <div class="field">
+    <%= form.label :status %>
+    <%= form.number_field :status, id: :interview_status %>
+  </div>
+
+  <div class="field">
+    <%= form.label :user_id %>
+    <%= form.text_field :user_id, id: :interview_user_id %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/interviews/_interview.json.jbuilder
+++ b/app/views/interviews/_interview.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! interview, :id, :start_time, :status, :user_id, :created_at, :updated_at
+json.url interview_url(interview, format: :json)

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Interview</h1>
+
+<%= render 'form', interview: @interview %>
+
+<%= link_to 'Show', @interview %> |
+<%= link_to 'Back', interviews_path %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -2,5 +2,7 @@
 
 <%= render 'form', interview: @interview %>
 
-<%= link_to 'Show', @interview %> |
-<%= link_to 'Back', interviews_path %>
+<hr>
+
+<%= link_to 'Show', user_interview_path, class: "btn btn-link" %> |
+<%= link_to t("page.move.back"), :back, class: "btn btn-link" %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,8 +1,7 @@
-<h1>Editing Interview</h1>
+<h1><%= t("interviews.edit") %>: <%= t("helpers.show_name", :name => @user.name) %></h1>
 
 <%= render 'form', interview: @interview %>
 
 <hr>
 
-<%= link_to 'Show', user_interview_path, class: "btn btn-link" %> |
 <%= link_to t("page.move.back"), :back, class: "btn btn-link" %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,31 +1,32 @@
-<p id="notice"><%= notice %></p>
+<h1>Interviews: <%= @user.name %></h1>
 
-<h1>Interviews</h1>
-
-<table>
+<table class="table table-bordered">
   <thead>
     <tr>
-      <th>Start time</th>
-      <th>Status</th>
-      <th>User</th>
-      <th colspan="3"></th>
+      <th scope="col" class="text-center">Start time</th>
+      <th scope="col" class="text-center">Status</th>
+      <th scope="col" colspan="2"></th>
     </tr>
   </thead>
 
   <tbody>
     <% @interviews.each do |interview| %>
       <tr>
-        <td><%= interview.start_time %></td>
-        <td><%= interview.status %></td>
-        <td><%= interview.user %></td>
-        <td><%= link_to 'Show', interview %></td>
-        <td><%= link_to 'Edit', edit_interview_path(interview) %></td>
-        <td><%= link_to 'Destroy', interview, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <th scope="row" class="text-center"><%= l(interview.start_time.in_time_zone, format: :long) %></th>
+        <td class="text-center"><%= interview.status %></td>
+        <td class="text-center">
+          <%= link_to 'Edit', edit_user_interview_path(@user, interview),
+            class: "btn btn-primary" %>
+        </td>
+        <td class="text-center">
+          <%= link_to 'Destroy', user_interview_path(@user, interview), method: :delete,
+            data: { confirm: 'Are you sure?' }, class: "btn btn-danger" %>
+        </td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<br>
+<hr>
 
-<%= link_to 'New Interview', new_interview_path %>
+<%= link_to 'New Interview', new_user_interview_path, class: "btn btn-primary" %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,0 +1,31 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Interviews</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Start time</th>
+      <th>Status</th>
+      <th>User</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @interviews.each do |interview| %>
+      <tr>
+        <td><%= interview.start_time %></td>
+        <td><%= interview.status %></td>
+        <td><%= interview.user %></td>
+        <td><%= link_to 'Show', interview %></td>
+        <td><%= link_to 'Edit', edit_interview_path(interview) %></td>
+        <td><%= link_to 'Destroy', interview, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Interview', new_interview_path %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,10 +1,14 @@
-<h1>Interviews: <%= @user.name %></h1>
+<h1><%= t("interviews.list") %>: <%= t("helpers.show_name", :name => @user.name) %></h1>
 
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th scope="col" class="text-center">Start time</th>
-      <th scope="col" class="text-center">Status</th>
+      <th scope="col" class="text-center">
+        <%= Interview.human_attribute_name("start_time") %>
+      </th>
+      <th scope="col" class="text-center">
+        <%= Interview.human_attribute_name("status") %>
+      </th>
       <th scope="col" colspan="2"></th>
     </tr>
   </thead>
@@ -12,15 +16,20 @@
   <tbody>
     <% @interviews.each do |interview| %>
       <tr>
-        <th scope="row" class="text-center"><%= l(interview.start_time.in_time_zone, format: :long) %></th>
-        <td class="text-center"><%= interview.status %></td>
+        <th scope="row" class="text-center">
+          <%= l(interview.start_time.in_time_zone, format: :long) %>
+        </th>
+        <td class="text-center"><%= interview.status_i18n %></td>
         <td class="text-center">
-          <%= link_to 'Edit', edit_user_interview_path(@user, interview),
+          <%= link_to t("page.move.edit"),
+            edit_user_interview_path(@user, interview),
             class: "btn btn-primary" %>
         </td>
         <td class="text-center">
-          <%= link_to 'Destroy', user_interview_path(@user, interview), method: :delete,
-            data: { confirm: 'Are you sure?' }, class: "btn btn-danger" %>
+          <%= link_to t("page.move.destroy"),
+            user_interview_path(@user, interview), method: :delete,
+            data: { confirm: t("helpers.destroy_confirmation") },
+            class: "btn btn-danger" %>
         </td>
       </tr>
     <% end %>
@@ -29,4 +38,5 @@
 
 <hr>
 
-<%= link_to 'New Interview', new_user_interview_path, class: "btn btn-primary" %>
+<%= link_to t("page.move.create"),
+  new_user_interview_path, class: "btn btn-primary" %>

--- a/app/views/interviews/index.json.jbuilder
+++ b/app/views/interviews/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @interviews, partial: 'interviews/interview', as: :interview

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Interview</h1>
+
+<%= render 'form', interview: @interview %>
+
+<%= link_to 'Back', interviews_path %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -2,4 +2,6 @@
 
 <%= render 'form', interview: @interview %>
 
-<%= link_to 'Back', interviews_path %>
+<hr>
+
+<%= link_to t("page.move.back"), :back %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New Interview</h1>
+<h1><%= t("interviews.new") %>: <%= t("helpers.show_name", :name => @user.name) %></h1>
 
 <%= render 'form', interview: @interview %>
 

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -1,17 +1,17 @@
 <p>
-  <strong>User:</strong>
+  <strong><%= Interview.human_attribute_name("user") %>:</strong>
   <%= @interview.user.name %>
 </p>
 
 <p>
-  <strong>Start time:</strong>
+  <strong><%= Interview.human_attribute_name("start_time") %>:</strong>
   <%= @interview.start_time %>
 </p>
 
 <p>
-  <strong>Status:</strong>
-  <%= @interview.status %>
+  <strong><%= Interview.human_attribute_name("status") %>:</strong>
+  <%= @interview.status_i18n %>
 </p>
 
-<%= link_to 'Edit', edit_user_interview_path, class: "btn btn-link" %> |
+<%= link_to t("page.move.edit"), edit_user_interview_path, class: "btn btn-link" %> |
 <%= link_to t("page.move.back"), :back, class: "btn btn-link" %>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -1,4 +1,7 @@
-<p id="notice"><%= notice %></p>
+<p>
+  <strong>User:</strong>
+  <%= @interview.user.name %>
+</p>
 
 <p>
   <strong>Start time:</strong>
@@ -10,10 +13,5 @@
   <%= @interview.status %>
 </p>
 
-<p>
-  <strong>User:</strong>
-  <%= @interview.user %>
-</p>
-
-<%= link_to 'Edit', edit_interview_path(@interview) %> |
-<%= link_to 'Back', interviews_path %>
+<%= link_to 'Edit', edit_user_interview_path, class: "btn btn-link" %> |
+<%= link_to t("page.move.back"), :back, class: "btn btn-link" %>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -5,7 +5,7 @@
 
 <p>
   <strong><%= Interview.human_attribute_name("start_time") %>:</strong>
-  <%= @interview.start_time %>
+  <%= l(@interview.start_time.in_time_zone, format: :long) %>
 </p>
 
 <p>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -1,0 +1,19 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Start time:</strong>
+  <%= @interview.start_time %>
+</p>
+
+<p>
+  <strong>Status:</strong>
+  <%= @interview.status %>
+</p>
+
+<p>
+  <strong>User:</strong>
+  <%= @interview.user %>
+</p>
+
+<%= link_to 'Edit', edit_interview_path(@interview) %> |
+<%= link_to 'Back', interviews_path %>

--- a/app/views/interviews/show.json.jbuilder
+++ b/app/views/interviews/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "interviews/interview", interview: @interview

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
                             %>
                         </li>
                         <li class="nav-item">
-                            <%= link_to '面接一覧',
+                            <%= link_to t("interviews.list"),
                                 user_interviews_path(current_user),
                                 class: "nav-link"
                             %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,12 @@
                             %>
                         </li>
                         <li class="nav-item">
+                            <%= link_to '面接一覧',
+                                user_interviews_path(current_user),
+                                class: "nav-link"
+                            %>
+                        </li>
+                        <li class="nav-item">
                             <%= link_to t("registrations.sign_out"),
                                 destroy_user_session_path,
                                 method: :delete,

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,9 @@ module ENavigator
     # デフォルト言語を日本語に
     config.i18n.default_locale = :ja
 
+    # 時刻はOSローカル時間で保存
+    config.active_record.default_timezone = :local
+
     # form_for のエラーが生成する <div class="field_with_errors"></div> を無効化
     # http://guides.rubyonrails.org/configuring.html#configuring-action-view
     config.action_view.field_error_proc = Proc.new do |html_tag, instance|

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,8 +31,11 @@ module ENavigator
     # デフォルト言語を日本語に
     config.i18n.default_locale = :ja
 
-    # 時刻はOSローカル時間で保存
-    config.active_record.default_timezone = :local
+    # タイムゾーン設定
+    config.time_zone = 'Tokyo'
+
+    # Heroku の PostgreSQL のデフォルトタイムゾーンはUTC
+    config.active_record.default_timezone = :utc
 
     # form_for のエラーが生成する <div class="field_with_errors"></div> を無効化
     # http://guides.rubyonrails.org/configuring.html#configuring-action-view

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -201,6 +201,6 @@ ja:
     am: 午前
     formats:
       default: "%Y/%m/%d %H:%M:%S"
-      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒"
       short: "%y/%m/%d %H:%M"
     pm: 午後

--- a/config/locales/my_en.yml
+++ b/config/locales/my_en.yml
@@ -3,6 +3,7 @@ en:
   activerecord:
     models:
       user: User
+      interview: Interview
     attributes:
       user:
         email: E-mail
@@ -16,17 +17,25 @@ en:
         birthday: Birthday
         gender: Gender
         school_name: "School name"
+      interview:
+        user: User
+        start_time: "Starting time"
+        status: "Approval status"
   enums:
     user:
       gender:
         male: Male
         female: Female
         other: Other
+    interview:
+      status:
+        approved: Approved
+        on_hold: "On hold"
+        rejected: Rejected
   registrations:
     sign_up: "Sign up"
     edit: "Edit your profile"
     destroy: "Cancel your account"
-    destroy_confirmation: "Are you sure?"
     sign_in: "Sign in"
     sign_out: "Sign out"
     forgot_password: "Forgot your password?"
@@ -34,10 +43,21 @@ en:
     leave_blank: "Leave blank if you don't want to change it."
     example_name: "John Smith"
     example_shool_name: "Hogwarts School of Witchcraft and Wizardry"
+  interviews:
+    new: "New interview"
+    list: "Interviews"
+    edit: "Edit an interview"
+    created: "Interview was successfully created."
+    updated: "Interview was successfully updated."
+    destroyed: "Interview was successfully destroyed."
   page:
     move:
       next: Next
       back: Back
+      create: Create
+      edit: Edit
+      destroy: Destroy
   helpers:
     welcome: Welcome
     show_name: "%{name}"
+    destroy_confirmation: "Are you sure?"

--- a/config/locales/my_ja.yml
+++ b/config/locales/my_ja.yml
@@ -3,6 +3,7 @@ ja:
   activerecord:
     models:
       user: ユーザー
+      interview: 面接
     attributes:
       user:
         email: メールアドレス
@@ -16,17 +17,25 @@ ja:
         birthday: 生年月日
         gender: 性別
         school_name: 学校名
+      interview:
+        user: ユーザー
+        start_time: 開始時間
+        status: 承認状態
   enums:
     user:
       gender:
         male: 男性
         female: 女性
         other: その他
+    interview:
+      status:
+        approved: 承認
+        on_hold: 保留
+        rejected: 却下
   registrations:
     sign_up: ユーザー登録
     edit: ユーザー編集
     destroy: ユーザー削除
-    destroy_confirmation: 本当に削除しますか？
     sign_in: ログイン
     sign_out: ログアウト
     forgot_password: パスワードを忘れましたか？
@@ -34,10 +43,21 @@ ja:
     leave_blank: 変更しない場合は入力しないでください
     example_name: "山田 太郎"
     example_shool_name: "東都大学"
+  interviews:
+    new: 面接登録
+    list: 面接一覧
+    edit: 面接編集
+    created: 面接を登録しました。
+    updated: 面接を更新しました。
+    destroyed: 面接を削除しました。
   page:
     move:
       next: 次へ
       back: 戻る
+      create: 登録
+      edit: 編集
+      destroy: 削除
   helpers:
     welcome: ようこそ
     show_name: "%{name}さん"
+    destroy_confirmation: 本当に削除しますか？

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :interviews
   root to: 'home#index'
 
   devise_for :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 Rails.application.routes.draw do
-  resources :interviews
   root to: 'home#index'
 
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  resources :users, only: [] do
+    resources :interviews
+  end
 end

--- a/db/migrate/20180319085356_create_interviews.rb
+++ b/db/migrate/20180319085356_create_interviews.rb
@@ -1,11 +1,11 @@
 class CreateInterviews < ActiveRecord::Migration[5.1]
   def change
     create_table :interviews do |t|
-      t.datetime :start_time
-      t.integer :status
+      t.datetime :start_time, default: -> { 'NOW()' } , null: false
+      t.integer :status, default: Interview.statuses[:rejected], null: false, limit: 1
       t.references :user, foreign_key: true
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20180319085356_create_interviews.rb
+++ b/db/migrate/20180319085356_create_interviews.rb
@@ -1,0 +1,11 @@
+class CreateInterviews < ActiveRecord::Migration[5.1]
+  def change
+    create_table :interviews do |t|
+      t.datetime :start_time
+      t.integer :status
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180318113806) do
+ActiveRecord::Schema.define(version: 20180319085356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "interviews", force: :cascade do |t|
+    t.datetime "start_time", default: -> { "now()" }, null: false
+    t.integer "status", limit: 2, default: 2, null: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_interviews_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -33,4 +42,5 @@ ActiveRecord::Schema.define(version: 20180318113806) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "interviews", "users"
 end


### PR DESCRIPTION
やりたかったこと
---

- 自分の面接日程のCRUD操作 (表示・登録・編集・削除) をできるようにする

やったこと
----

- User と1対多の Interview モデルの追加
- 面接ページの追加

動作確認方法
---

- [ ] 面接一覧ページにいく
- [ ] 新しく面接を登録する
- [ ] 登録した面接を編集する
- [ ] 登録した面接を削除する

その他
---

- 前回のレビューを活かし、 generator での生成でもコミットを分けるようにしました
- 第1章では他のユーザーの面接に対しては言及がなかったので、現状だと他のユーザーの面接日程のCRUD操作も  (URLを弄れば) できちゃいますが、大丈夫でしょうか